### PR TITLE
Add -fno-fat-lto-objects to build command line

### DIFF
--- a/zebROS_ws/rostoolchain.cmake
+++ b/zebROS_ws/rostoolchain.cmake
@@ -18,7 +18,7 @@ set(Boost_NO_SYSTEM_PATHS=ON)
 
 find_program(CMAKE_RANLIB ${ARM_PREFIX}-gcc-ranlib)
 find_program(CMAKE_AR ${ARM_PREFIX}-gcc-ar)
-set(OPT_FLAGS "-O3 -flto=4 -mcpu=cortex-a9 -mfpu=neon -fvect-cost-model -ffunction-sections -fdata-sections -Wl,-gc-sections")
+set(OPT_FLAGS "-O3 -flto=2 -fno-fat-lto-objects -mcpu=cortex-a9 -mfpu=neon -fvect-cost-model -ffunction-sections -fdata-sections -Wl,-gc-sections")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${OPT_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} ${OPT_FLAGS}")
 set(CMAKE_INSTALL_RPATH "$ENV{HOME}/wpilib/2020/roborio/arm-frc2020-linux-gnueabi/opt/ros/melodic/lib")

--- a/zebROS_ws/src/cmake_modules/CMakeOpt.cmake
+++ b/zebROS_ws/src/cmake_modules/CMakeOpt.cmake
@@ -17,7 +17,7 @@ else() # Native builds
   set (CMAKE_RANLIB "gcc-ranlib" )
   set (CMAKE_AR     "gcc-ar"     )
   
-  set (OPT_FLAGS "${OPT_FLAGS} -Ofast -fno-finite-math-only -flto=2")
+  set (OPT_FLAGS "${OPT_FLAGS} -Ofast -fno-finite-math-only -flto=2 -fno-fat-lto-objects")
   if (${CMAKE_LIBRARY_ARCHITECTURE} STREQUAL "arm-linux-gnueabihf") # Jetson TK1
 	set (OPT_FLAGS "${OPT_FLAGS} -mcpu=cortex-a15 -mfpu=neon-vfpv4 -fvect-cost-model")
     unset(CUDA_USE_STATIC_CUDA_RUNTIME CACHE)


### PR DESCRIPTION
By default, when compiling using link-time-optimization, GCC emits both the intermediate form used by the link-time optimizer and also normal object code. Since we build everything using LTO, this is redundant - the normal object code can be omitted. Adding the flag above does that - should speed up builds a bit?