### PR TITLE
Fix the weird bug that disappeared when you pressed the right trigger.

### DIFF
--- a/zebROS_ws/src/teleop_joystick_control/include/teleop_joystick_control/TeleopCmdVel.h
+++ b/zebROS_ws/src/teleop_joystick_control/include/teleop_joystick_control/TeleopCmdVel.h
@@ -9,12 +9,7 @@ class TeleopCmdVel
 		TeleopCmdVel(const teleop_joystick_control::TeleopJoystickCompConfig &config):
 			x_rate_limit_(-config.max_speed, config.max_speed, config.drive_rate_limit_time),
 			y_rate_limit_(-config.max_speed, config.max_speed, config.drive_rate_limit_time),
-			rotation_rate_limit_(-config.max_rot, config.max_rot, config.drive_rate_limit_time)
-		{
-			max_speed_ = config.max_speed;
-			max_rot_ = config.max_rot;
-
-		}
+			rotation_rate_limit_(-config.max_rot, config.max_rot, config.drive_rate_limit_time){}
 
 		void setRobotOrient(const bool &robot_orient, const double &offset_angle)
 		{
@@ -29,12 +24,12 @@ class TeleopCmdVel
 
 		geometry_msgs::Twist generateCmdVel(const frc_msgs::JoystickState &event, const double &navX_angle, const teleop_joystick_control::TeleopJoystickCompConfig &config)
 		{
-			max_speed_ = slow_mode_ ? config.max_speed_slow : config.max_speed;
-			max_rot_ = slow_mode_ ? config.max_rot_slow : config.max_rot;
+			double max_speed = slow_mode_ ? config.max_speed_slow : config.max_speed;
+			double max_rot = slow_mode_ ? config.max_rot_slow : config.max_rot;
 
-			x_rate_limit_.updateMinMax(-max_speed_, max_speed_);
-			y_rate_limit_.updateMinMax(-max_speed_, max_speed_);
-			rotation_rate_limit_.updateMinMax(-max_rot_, max_rot_);
+			x_rate_limit_.updateMinMax(-max_speed, max_speed);
+			y_rate_limit_.updateMinMax(-max_speed, max_speed);
+			rotation_rate_limit_.updateMinMax(-max_rot, max_rot);
 
 			// Raw joystick values for X & Y translation
 			const double leftStickX = event.leftStickX;
@@ -57,7 +52,7 @@ class TeleopCmdVel
 			{
 				magnitude = pow(magnitude, config.joystick_pow);
 				//ROS_INFO_STREAM(__LINE__ << " "  << magnitude << " " << direction);
-				magnitude *= max_speed_ - config.min_speed;
+				magnitude *= max_speed - config.min_speed;
 				//ROS_INFO_STREAM(__LINE__ << " "  << magnitude);
 				magnitude += config.min_speed;
 				//ROS_INFO_STREAM(__LINE__ << " "  << magnitude);
@@ -80,7 +75,7 @@ class TeleopCmdVel
 			// of the original input (keeps the direction correct)
 			double rotation = pow(rightStickX, config.rotation_pow);
 			rotation  = copysign(rotation, event.rightStickX);
-			rotation *= max_rot_;
+			rotation *= max_rot;
 
 			// Rate-limit changes in rotation
 			rotation = rotation_rate_limit_.applyLimit(rotation, event.header.stamp);
@@ -120,8 +115,6 @@ class TeleopCmdVel
 		bool robot_orient_ = false;
 		bool slow_mode_ = false;
 
-		double max_speed_;
-		double max_rot_;
 		double offset_angle_;
 
 		rate_limiter::RateLimiter x_rate_limit_;


### PR DESCRIPTION
Turns out the teleop driving class constructor was trying to initialize rate limiting objects with variables that had yet to be assigned values. Not sure why we got the behavior we did, but it should be fixed now. 