### PR TITLE
Update ros_control_boilerplate init/read/write 

### DIFF
--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/AS726x.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/AS726x.h
@@ -392,6 +392,7 @@ class roboRIO_AS726x : public AS726x
 {
 	public:
 		roboRIO_AS726x(const frc::I2C::Port &port, int deviceAddress = AS726x_ADDRESS);
+		virtual ~roboRIO_AS726x() { }
 	private:
 		virtual void read(uint8_t reg, uint8_t *buf, uint8_t num) override;
 		virtual void write(uint8_t reg, uint8_t *buf, uint8_t num) override;

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/frc_robot_interface.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/frc_robot_interface.h
@@ -109,13 +109,13 @@ class FRCRobotInterface : public hardware_interface::RobotHW
 		virtual ~FRCRobotInterface() {}
 
 		/** \brief Initialize the hardware interface */
-		virtual void init();
+		virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
 
 		/** \brief Read the state from the robot hardware. */
-		virtual void read(ros::Duration &elapsed_time) = 0;
+		virtual void read(const ros::Time& time, const ros::Duration& period) override = 0;
 
 		/** \brief Write the command to the robot hardware. */
-		virtual void write(ros::Duration &elapsed_time) = 0;
+		virtual void write(const ros::Time& time, const ros::Duration& period) override = 0;
 
 		/** \brief Set all members to default values */
 		virtual void reset();
@@ -126,8 +126,8 @@ class FRCRobotInterface : public hardware_interface::RobotHW
 		 * with regard to necessary hardware interface switches. Start and stop list are disjoint.
 		 * This is just a check, the actual switch is done in doSwitch()
 		 */
-		virtual bool canSwitch(const std::list<hardware_interface::ControllerInfo> &/*start_list*/,
-							   const std::list<hardware_interface::ControllerInfo> &/*stop_list*/) const
+		virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo> &/*start_list*/,
+							       const std::list<hardware_interface::ControllerInfo> &/*stop_list*/) override
 		{
 			return true;
 		}
@@ -138,7 +138,7 @@ class FRCRobotInterface : public hardware_interface::RobotHW
 		 * Start and stop list are disjoint. The feasability was checked in canSwitch() beforehand.
 		 */
 		virtual void doSwitch(const std::list<hardware_interface::ControllerInfo> &/*start_list*/,
-							  const std::list<hardware_interface::ControllerInfo> &/*stop_list*/)
+							  const std::list<hardware_interface::ControllerInfo> &/*stop_list*/) override
 		{
 		}
 
@@ -156,9 +156,6 @@ class FRCRobotInterface : public hardware_interface::RobotHW
 
 		// Short name of this class
 		std::string name_;
-
-		// Startup and shutdown of the internal node inside a roscpp program
-		ros::NodeHandle nh_;
 
 		// Hardware interfaces
 		hardware_interface::JointStateInterface                joint_state_interface_;

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/frcrobot_hw_interface.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/frcrobot_hw_interface.h
@@ -154,13 +154,13 @@ class FRCRobotHWInterface : public ros_control_boilerplate::FRCRobotInterface
 		~FRCRobotHWInterface();
 
 		/** \brief Initialize the hardware interface */
-		virtual void init(void) override;
+		virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
 
 		/** \brief Read the state from the robot hardware. */
-		virtual void read(ros::Duration &elapsed_time) override;
+		virtual void read(const ros::Time& time, const ros::Duration& period) override;
 
 		/** \brief Write the command to the robot hardware. */
-		virtual void write(ros::Duration &elapsed_time) override;
+		virtual void write(const ros::Time& time, const ros::Duration& period) override;
 
 	private:
 		/* Get conversion factor for position, velocity, and closed-loop stuff */

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/frcrobot_phoenixsim_interface.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/frcrobot_phoenixsim_interface.h
@@ -9,13 +9,13 @@ class FRCRobotPhoenixSimInterface : public FRCRobotHWInterface
 {
 	public:
 		FRCRobotPhoenixSimInterface(ros::NodeHandle &nh, urdf::Model *urdf_model = NULL);
-		virtual void init(void) override;
+		virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
 
 		/** \brief Read the state from the robot hardware. */
-		//virtual void read(ros::Duration &elapsed_time) override;
+		//virtual void read(const ros::Time& time, const ros::Duration& period) override;
 
 		/** \brief Write the command to the robot hardware. */
-		virtual void write(ros::Duration &elapsed_time) override;
+		virtual void write(const ros::Time& time, const ros::Duration& period) override;
 
 };
 

--- a/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/frcrobot_sim_interface.h
+++ b/zebROS_ws/src/ros_control_boilerplate/include/ros_control_boilerplate/frcrobot_sim_interface.h
@@ -64,13 +64,13 @@ class FRCRobotSimInterface : public ros_control_boilerplate::FRCRobotInterface
 		FRCRobotSimInterface(ros::NodeHandle &nh, urdf::Model *urdf_model = NULL);
 		~FRCRobotSimInterface();
 
-		virtual void init(void) override;
+		virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
 
 		/** \brief Read the state from the robot hardware. */
-		virtual void read(ros::Duration &elapsed_time) override;
+		virtual void read(const ros::Time& time, const ros::Duration& period) override;
 
 		/** \brief Write the command to the robot hardware. */
-		virtual void write(ros::Duration &elapsed_time) override;
+		virtual void write(const ros::Time& time, const ros::Duration& period) override;
 
 		virtual bool setlimit(ros_control_boilerplate::set_limit_switch::Request &req,ros_control_boilerplate::set_limit_switch::Response &res);
 

--- a/zebROS_ws/src/ros_control_boilerplate/src/frc_robot_interface.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frc_robot_interface.cpp
@@ -76,7 +76,6 @@ void FRCRobotInterface::readJointLocalParams(XmlRpc::XmlRpcValue joint_params,
 
 FRCRobotInterface::FRCRobotInterface(ros::NodeHandle &nh, urdf::Model *urdf_model) :
 	  name_("generic_hw_interface")
-	, nh_(nh)
 	, num_can_ctre_mcs_(0)
 	, num_nidec_brushlesses_(0)
 	, num_digital_inputs_(0)
@@ -99,7 +98,7 @@ FRCRobotInterface::FRCRobotInterface(ros::NodeHandle &nh, urdf::Model *urdf_mode
 		urdf_model_ = urdf_model;
 
 	// Load rosparams
-	ros::NodeHandle rpnh(nh_, "hardware_interface"); // TODO(davetcoleman): change the namespace to "frc_robot_interface" aka name_
+	ros::NodeHandle rpnh(nh, "hardware_interface"); // TODO(davetcoleman): change the namespace to "frc_robot_interface" aka name_
 
 	// Read a list of joint information from ROS parameters.  Each entry in the list
 	// specifies a name for the joint and a hardware ID corresponding
@@ -719,7 +718,7 @@ FRCRobotInterface::FRCRobotInterface(ros::NodeHandle &nh, urdf::Model *urdf_mode
 	can_interface_ = rpnh.param<std::string>("can_interface", "can0");
 }
 
-void FRCRobotInterface::init()
+bool FRCRobotInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
 {
 	num_can_ctre_mcs_ = can_ctre_mc_names_.size();
 	// Create vectors of the correct size for
@@ -1146,6 +1145,7 @@ void FRCRobotInterface::init()
 	registerInterface(&as726x_remote_state_interface_);
 
 	ROS_INFO_STREAM_NAMED(name_, "FRCRobotInterface Ready.");
+	return true;
 }
 
 // Using the mode, setpoint, etc generated from a given Talon's custom profile,

--- a/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_hw_main.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_hw_main.cpp
@@ -37,7 +37,7 @@
 */
 
 
-//PURPOSE: Pulls togther stuff needed to run hw interface 
+//PURPOSE: Pulls togther stuff needed to run hw interface
 
 #include <ros_control_boilerplate/generic_hw_control_loop.h>
 #include <ros_control_boilerplate/frcrobot_hw_interface.h>
@@ -46,6 +46,7 @@ int main(int argc, char **argv)
 {
 	ros::init(argc, argv, "frcrobot_hw_interface");
 	ros::NodeHandle nh;
+	ros::NodeHandle robot_nh(nh, "hardware_interface");
 
 	// NOTE: We run the ROS loop in a separate thread as external calls such
 	// as service callbacks to load controllers can block the (main) control loop
@@ -55,12 +56,16 @@ int main(int argc, char **argv)
 	// Create the hardware interface specific to your robot
 	std::shared_ptr<frcrobot_control::FRCRobotHWInterface> frcrobot_hw_interface
 	(new frcrobot_control::FRCRobotHWInterface(nh));
-	frcrobot_hw_interface->init();
+	if (!frcrobot_hw_interface->init(nh, robot_nh))
+	{
+		ROS_ERROR_STREAM(__PRETTY_FUNCTION__ << " : frcrobot_hw_interface->init() returned false");
+		return -1;
+	}
 
 	// Start the control loop
 	ros_control_boilerplate::GenericHWControlLoop control_loop(nh, frcrobot_hw_interface);
 
-	control_loop.run(); // Blocks until shutdown signal recieved 
+	control_loop.run(); // Blocks until shutdown signal recieved
 
 	return 0;
 }

--- a/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_phoenixsim_interface.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_phoenixsim_interface.cpp
@@ -13,7 +13,7 @@ FRCRobotPhoenixSimInterface::FRCRobotPhoenixSimInterface(ros::NodeHandle &nh, ur
 {
 }
 
-void FRCRobotPhoenixSimInterface::init(void)
+bool FRCRobotPhoenixSimInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
 {
 	for (size_t i = 0; i < can_ctre_mc_can_ids_.size(); i++)
 	{
@@ -28,16 +28,21 @@ void FRCRobotPhoenixSimInterface::init(void)
 	ros::Duration(1.0).sleep();
 
 	hal::init::InitializeHAL();
-	FRCRobotHWInterface::init();
+	if (!FRCRobotHWInterface::init(root_nh, robot_hw_nh))
+	{
+		ROS_ERROR_STREAM(__PRETTY_FUNCTION__ << " : FRCRobotHWInterface::init() returned false");
+		return false;
+	}
+	return true;
 }
 
 
 // Write should grab the motor output and use it to run 1 timestep
 // of the underlying motor sim
-void FRCRobotPhoenixSimInterface::write(ros::Duration &elapsed_time)
+void FRCRobotPhoenixSimInterface::write(const ros::Time& time, const ros::Duration& period)
 {
 	c_FeedEnable(500);
-	FRCRobotHWInterface::write(elapsed_time);
+	FRCRobotHWInterface::write(time, period);
 
 	// Update the motor connected to each Talon here?
 }

--- a/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_phoenixsim_main.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_phoenixsim_main.cpp
@@ -43,6 +43,7 @@ int main(int argc, char **argv)
 {
 	ros::init(argc, argv, "frcrobot_phoenixsim_interface");
 	ros::NodeHandle nh;
+	ros::NodeHandle robot_nh(nh, "hardware_interface");
 
 	// NOTE: We run the ROS loop in a separate thread as external calls such
 	// as service callbacks to load controllers can block the (main) control loop
@@ -52,7 +53,11 @@ int main(int argc, char **argv)
 	// Create the hardware interface specific to your robot
 	std::shared_ptr<frcrobot_control::FRCRobotPhoenixSimInterface> frcrobot_phoenixsim_interface
 		(new frcrobot_control::FRCRobotPhoenixSimInterface(nh));
-	frcrobot_phoenixsim_interface->init();
+	if (!frcrobot_phoenixsim_interface->init(nh, robot_nh))
+	{
+		ROS_ERROR_STREAM(__PRETTY_FUNCTION__ << " : frcrobot_phoenixsim_interface->init() returned false");
+		return -1;
+	}
 
 	// Start the control loop
 	ros_control_boilerplate::GenericHWControlLoop control_loop(nh, frcrobot_phoenixsim_interface);

--- a/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_sim_main.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_sim_main.cpp
@@ -43,6 +43,7 @@ int main(int argc, char **argv)
 {
 	ros::init(argc, argv, "frcrobot_hw_interface");
 	ros::NodeHandle nh;
+	ros::NodeHandle robot_nh(nh, "hardware_interface");
 
 	// NOTE: We run the ROS loop in a separate thread as external calls such
 	// as service callbacks to load controllers can block the (main) control loop
@@ -52,7 +53,11 @@ int main(int argc, char **argv)
 	// Create the hardware interface specific to your robot
 	std::shared_ptr<frcrobot_control::FRCRobotSimInterface> frcrobot_sim_interface
 	(new frcrobot_control::FRCRobotSimInterface(nh));
-	frcrobot_sim_interface->init();
+	if (!frcrobot_sim_interface->init(nh, robot_nh))
+	{
+		ROS_ERROR_STREAM(__PRETTY_FUNCTION__ << " : frcrobot_sim_interface->init() returned false");
+		return -1;
+	}
 
 	// Start the control loop
 	ros_control_boilerplate::GenericHWControlLoop control_loop(nh, frcrobot_sim_interface);

--- a/zebROS_ws/src/ros_control_boilerplate/src/generic_hw_control_loop.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/generic_hw_control_loop.cpp
@@ -98,7 +98,7 @@ void GenericHWControlLoop::update(void)
 
 	// Input
 	tracer_.start_unique("read");
-	hardware_interface_->read(elapsed_time_);
+	hardware_interface_->read(ros::Time::now(), elapsed_time_);
 
 	// Control
 	tracer_.start_unique("update");
@@ -106,7 +106,7 @@ void GenericHWControlLoop::update(void)
 
 	// Output
 	tracer_.start_unique("write");
-	hardware_interface_->write(elapsed_time_);
+	hardware_interface_->write(ros::Time::now(), elapsed_time_);
 	tracer_.stop();
 
 	ROS_INFO_STREAM_THROTTLE(20, tracer_.report());


### PR DESCRIPTION
to match melodic updates to robotHW

Looks like at some point the ROS baseline versions of init, read and write for the main control  loop were changed. This PR updates the ros control boilerplate code to match.

Works in sim, but needs to be tested on a robot.