### PR TITLE
Method to Zero Turret

### DIFF
--- a/zebROS_ws/src/controllers_2020/include/controllers_2020/turret_controller.h
+++ b/zebROS_ws/src/controllers_2020/include/controllers_2020/turret_controller.h
@@ -47,15 +47,12 @@ class TurretController : public controller_interface::MultiInterfaceController<h
 
 			bool zeroed_;
 			bool last_zeroed_;
-			double last_position_;
 
 			double turret_zero_timeout_;
 			double turret_zero_percent_output_;
+			double turret_zero_angle_;
 
-			//double last_setpoint_;
-			hardware_interface::TalonMode last_mode_;
-
-			ros::Time last_time_down_;
+			ros::Time last_time_moving_;
 }; //class
 
 } //namespace

--- a/zebROS_ws/src/ros_control_boilerplate/config/2020_compbot_base_jetson.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2020_compbot_base_jetson.yaml
@@ -174,6 +174,7 @@ turret_controller:
 
     turret_zero_timeout: 5.0
     turret_zero_percent_output: 0.1
+    turret_zero_angle: 1.0472
 
     turret:
         type: talon_controllers/TalonMotionMagicCloseLoopController


### PR DESCRIPTION
Similar to (copy and pasted with minor adjustments) last year's elevator zeroing code, the turret is set up to zero by running in percent out mode into a limit switch on the far right side of the allowable angle. When it hits the limit switch, it sets the current position to -pi/3, making the center zero and switches back to normal motion profile.