### PR TITLE
Relative Heights of Vision Targets

### DIFF
--- a/common/objtype.cpp
+++ b/common/objtype.cpp
@@ -217,7 +217,7 @@ ObjectType::ObjectType(ObjectNum contour_type_id=UNINITIALIZED) {
 			break;
 		case POWER_PORT_2020: //target on the POWER PORT (2020)
 			depth_ = 0;
-			real_height_ = 1.48463; // TODO: Fix this using actual height
+			real_height_ = 1.4796516; // TODO: Fix this using actual height
 			contour_.push_back(Point2f(0,0));
 			contour_.push_back(Point2f(0.2492375,0.4318));
 			contour_.push_back(Point2f(0.7477125,0.4318));
@@ -230,7 +230,7 @@ ObjectType::ObjectType(ObjectNum contour_type_id=UNINITIALIZED) {
 			break;
 		case LOADING_BAY_2020: //target on the LOADING BAY (2020)
 			depth_ = 0;
-			real_height_ = -.29972; // TODO: fix this using actual height
+			real_height_ = -.3046984:; // TODO: fix this using actual height
 			contour_.push_back(Point2f(0.0508,0.2286));
 			contour_.push_back(Point2f(0.0508,0));
 			contour_.push_back(Point2f(0,0));


### PR DESCRIPTION
Used two different measurements for the height of the zed camera on the assembly.
~22.7 to 22.9 inches

Game manual information:
The loading bay vision target is 11 in above the carpet
The power port vision target is 81.25 in above the carpet

Loading Bay: 11 - 22.8 = -11.8 in -> -.29972 Meters
Power Port: 81.25 - 22.8in = 58.45 in -> 1.48463 Meters