### PR TITLE
Add preempting eject upon button release

### DIFF
--- a/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2020.cpp
+++ b/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2020.cpp
@@ -194,6 +194,7 @@ void buttonBoxCallback(const ros::MessageEvent<frc_msgs::ButtonBoxState const>& 
 	}
 	if(button_box.leftRedRelease)
 	{
+		eject_ac->cancelGoalsAtAndBeforeTime(ros::Time::now());
 	}
 
 	if(button_box.rightRedPress)
@@ -211,6 +212,7 @@ void buttonBoxCallback(const ros::MessageEvent<frc_msgs::ButtonBoxState const>& 
 	}
 	if(button_box.rightRedRelease)
 	{
+		eject_ac->cancelGoalsAtAndBeforeTime(ros::Time::now());
 	}
 
 	if(button_box.leftSwitchUpPress)


### PR DESCRIPTION
Eject should actually terminate after buttons are released now.