### PR TITLE
base_trajectory_msgs shouldn't depend on joint_trajectory_controller

### DIFF
--- a/zebROS_ws/src/base_trajectory_msgs/CMakeLists.txt
+++ b/zebROS_ws/src/base_trajectory_msgs/CMakeLists.txt
@@ -8,10 +8,11 @@ project(base_trajectory_msgs)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  joint_trajectory_controller
+  geometry_msgs
   message_generation
   nav_msgs
   std_msgs
+  trajectory_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -72,6 +73,7 @@ generate_messages(
    std_msgs  # Or other packages containing msgs
    nav_msgs
    trajectory_msgs
+   geometry_msgs
    base_trajectory_msgs
 )
 

--- a/zebROS_ws/src/base_trajectory_msgs/package.xml
+++ b/zebROS_ws/src/base_trajectory_msgs/package.xml
@@ -7,7 +7,7 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="kjaget@todo.todo">kjaget</maintainer>
+  <maintainer email="programmers@team900.org">FRC Team 900 Programmers</maintainer>
 
 
   <!-- One license tag required, multiple allowed, one license per tag -->
@@ -49,21 +49,20 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>joint_trajectory_controller</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_export_depend>joint_trajectory_cntroller</build_export_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>trajectory_msgs</build_depend>
   <build_export_depend>nav_msgs</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
-  <exec_depend>joint_trajectory_cntroller</exec_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <build_export_depend>trajectory_msgs</build_export_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->
-
   </export>
 </package>


### PR DESCRIPTION
It just needs to depend on trajectory_msgs, so removing the dependency on joint_trajectory_controller should increase opportunities for parallel builds of things which depend on it (for example, behaviors)